### PR TITLE
Increase limit on contentType query to maximum (1k)

### DIFF
--- a/src/schema-downloader/index.ts
+++ b/src/schema-downloader/index.ts
@@ -69,8 +69,12 @@ export class SchemaDownloader {
     const env = await this.semaphore.lock<any>(() =>
       space.getEnvironment(this.options.environment))
 
+    // By default, the Contentful API will limit results to 100 items.
+    // To avoid truncated results for environments with >100 content types, 
+    // we set the limit to the maximum allowed by Contentful (1000). 
+    // See: https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/order-with-multiple-parameters 
     const contentTypesResp = await this.semaphore.lock<any>(() =>
-      env.getContentTypes())
+      env.getContentTypes({ limit: 1000 }))
 
     const editorInterfaces = (await Promise.all<any>(
       contentTypesResp.items.map((ct: any) =>


### PR DESCRIPTION
We currently have an environment that is approaching >100 content types - Using `contentful-ts-generator`, the resulting schema/type definitions are omitting content types after that 100 limit is reached. 

As per [Contentful](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/reverse-order), the default limit on these queries is `100` and the maximum allowed limit is `1000`.  This PR defines `limit: 1000` in the opts for `getContentTypes` in order to surpass the default `100` limit and to avoid environments with >100 content types from receiving omitted type definitions.